### PR TITLE
Suggestion about the location of the dist/ directory

### DIFF
--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -373,7 +373,7 @@ This directory will be at the root of your project:
     │   └── example_package_YOUR_USERNAME_HERE/
     │       ├── __init__.py
     │       └── example.py
-    └── tests/
+    ├── tests/
     └── dist/
         ├── example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
         └── example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz

--- a/source/tutorials/packaging-projects.rst
+++ b/source/tutorials/packaging-projects.rst
@@ -361,6 +361,22 @@ files in the :file:`dist` directory:
     ├── example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
     └── example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
 
+This directory will be at the root of your project:
+
+.. code-block:: text
+
+    packaging_tutorial/
+    ├── LICENSE
+    ├── pyproject.toml
+    ├── README.md
+    ├── src/
+    │   └── example_package_YOUR_USERNAME_HERE/
+    │       ├── __init__.py
+    │       └── example.py
+    └── tests/
+    └── dist/
+        ├── example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
+        └── example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
 
 The ``tar.gz`` file is a :term:`source distribution <Source Distribution (or "sdist")>`
 whereas the ``.whl`` file is a :term:`built distribution <Built Distribution>`.


### PR DESCRIPTION
When reading your excellent tutorial I got surprised because no indication of where dist/ directory will be located. This is a proposal for the text. Maybe it would be better to substitute the original lines:

```
dist/
├── example_package_YOUR_USERNAME_HERE-0.0.1-py3-none-any.whl
└── example_package_YOUR_USERNAME_HERE-0.0.1.tar.gz
```
But not sure, I can provide a patch, if you prefer.